### PR TITLE
Safer handling of encryption and decryption of shop ID

### DIFF
--- a/Controller/Component/SofortlibComponent.php
+++ b/Controller/Component/SofortlibComponent.php
@@ -74,7 +74,6 @@ class SofortlibComponent extends Component
 
     public function HandleNotifyUrl($eShopId, $status, $ip, $rawPostStream = 'php://input')
     {
-        debug($this->Config);
         $shop_id = Security::rijndael(
                 self::Base64Decode($eShopId),
                 Configure::read('Security.salt'),

--- a/Test/Case/Controller/Component/SofortlibComponentTest.php
+++ b/Test/Case/Controller/Component/SofortlibComponentTest.php
@@ -1,0 +1,62 @@
+<?php
+App::uses('SofortlibComponent', 'SofortCom.Controller/Component');
+
+/**
+ * Encryption and Decryption Tests
+ */
+class SofortlibComponentTest extends CakeTestCase {
+
+	/**
+	 * setUp method
+	 *
+	 * @return void
+	 */
+	public function setUp(){
+		parent::setUp();
+	}
+
+	/**
+	 * tearDown method
+	 *
+	 * @return void
+	 */
+	public function tearDown(){
+		parent::tearDown();
+	}
+
+	private function getRandomShopId(){
+		return String::uuid();
+	}
+
+	/**
+	 * @group combined
+	 */
+	public function testEncryptDecrypt(){
+		$shopId = 72;
+		$enc = SofortlibComponent::EncryptShopId($shopId);
+
+		// simulate CakePHP's URL param decoding
+		$urlParam = urldecode($enc);
+
+		$dec = SofortlibComponent::DecryptShopId($urlParam);
+		$this->assertEquals($shopId, $dec);
+	}
+
+	/**
+	 * @group combined
+	 */
+	public function testEncryptDecrypt10000RandomIds(){
+		for($i=0; $i<10000; $i++){
+			$shopId = $this->getRandomShopId();
+
+			$enc = SofortlibComponent::EncryptShopId($shopId);
+
+			// simulate CakePHP's URL param decoding
+			$urlParam = urldecode($enc);
+
+			$dec = SofortlibComponent::DecryptShopId($urlParam);
+			$this->assertEquals($shopId, $dec);
+		}
+	}
+
+}


### PR DESCRIPTION
I experienced problems when there where +-signs in the encoded URL, because CakePHP then decodes this param so that there is a space instead, which is then wrongly decrypted...
